### PR TITLE
Update Bulgarian translations for various messages

### DIFF
--- a/locale/trayslate.bg.po
+++ b/locale/trayslate.bg.po
@@ -120,18 +120,14 @@ msgid "Measurement Units"
 msgstr "Мерни единици"
 
 #: formpopup.rlockautpheight
-#, fuzzy
-#| msgid "Lock Auto Height"
 msgctxt "formpopup.rlockautpheight"
 msgid "Lock Height"
-msgstr "Заключи автоматичната височина"
+msgstr "Заключи височината"
 
 #: formpopup.runlockautoheight
-#, fuzzy
-#| msgid "Unlock Auto Height"
 msgctxt "formpopup.runlockautoheight"
 msgid "Unlock Height"
-msgstr "Отключи автоматичната височина"
+msgstr "Отключи височината"
 
 #: formsettings.rapp
 msgctxt "formsettings.rapp"
@@ -386,27 +382,7 @@ msgid ""
 "   License: BSD-style license\n"
 "   Copyright (c) 1999–2024, Lukas Gebauer\n"
 "   https://github.com/geby/synapse"
-msgstr ""
-"Trayslate е базиран на трей клиент за преводачески услуги. Може да въвеждате текст директно, да превеждате съдържанието на клипборда или превеждате избран текст във всяко приложение. Може също да замените текст в друго приложение с неговия превод, като използвате клавишна комбинация. Приложението позволява да изберете и напълно да конфигурирате услугата за превод, която използвате.\n"
-"\n"
-"Това приложение използва ресурси на трети страни под лицензи:\n"
-"\n"
-"1. Основна икона, проектирана от Flaticon\n"
-"   https://www.flaticon.com/ru/free-icon/translator_682045\n"
-"\n"
-"2. Модули за поддръжка на тъмна тема от Double Commander\n"
-"   Използвани модули: udarkstyle.pas, uimport.pas, uwin32widgetsetdark.pas\n"
-"   Лиценз: GNU General Public License v2.0 (GPL-2.0)\n"
-"   https://github.com/doublecmd/doublecmd\n"
-"   \n"
-"3. OpenSSL библиотеки (32-битови и 64-битови версии)\n"
-"   Лиценз: Apache License 2.0\n"
-"   https://www.openssl.org\n"
-"\n"
-"4. Мрежова библиотека Synapse (laz_synapse / synapse41.0)   \n"
-"   Лиценз: в стил BSD\n"
-"   Авторско право (c) 1999–2024, Лукас Гебауер\n"
-"   https://github.com/geby/synapse"
+msgstr "Trayslate е базиран на трей клиент за преводачески услуги. Може да въвеждате текст директно, да превеждате съдържанието на клипборда или превеждате избран текст във всяко приложение. Може също да замените текст в друго приложение с неговия превод, като използвате клавишна комбинация. Приложението позволява да изберете и напълно да конфигурирате услугата за превод, която използвате.\n\nТова приложение използва ресурси на трети страни под лицензи:\n\n1. Основна икона, проектирана от Flaticon\n   https://www.flaticon.com/ru/free-icon/translator_682045\n\n2. Модули за поддръжка на тъмна тема от Double Commander\n   Използвани модули: udarkstyle.pas, uimport.pas, uwin32widgetsetdark.pas\n   Лиценз: GNU General Public License v2.0 (GPL-2.0)\n   https://github.com/doublecmd/doublecmd\n   \n3. OpenSSL библиотеки (32-битови и 64-битови версии)\n   Лиценз: Apache License 2.0\n   https://www.openssl.org\n\n4. Мрежова библиотека Synapse (laz_synapse / synapse41.0)   \n   Лиценз: в стил BSD\n   Авторско право (c) 1999–2024, Лукас Гебауер\n   https://github.com/geby/synapse"
 
 #: tformbuttontrayslate.imagetranslate.hint
 msgctxt "tformbuttontrayslate.imagetranslate.hint"
@@ -611,15 +587,7 @@ msgid ""
 "Commenting: /* text */ comments are stripped from the entire expression before any processing.\n"
 "Examples:\n"
 "responseData/translatedText; matches/*#10/translation; /texts/text; {literal text#10}; /result/text; /text{ ({(\\w+)})}; !/translations{Error: No data!#10}; /translations/0/text"
-msgstr ""
-"Json показалец: Използва / за нива, ключове за обекти и числа за индекси. Използва * за всички елементи, *#10 за свързване на елементи чрез нов ред. Използвайте ~ в края на пътя, за да върнете необработения JSON клон. Разделете няколко сегмента с точка и запетая ;.\n"
-"Литерал: Текстов блок в {…}. Специален етикет #10 за нови редове. Използвайте {{regex}} вътре, за да извлечете данни директно в текста.\n"
-"Логика: Ако указател в сегмент е празен, целият сегмент се пропуска. Ако даден сегмент няма указател, се обработват само буквални текстови блокове с вградени регулярни изрази.\n"
-"Regex: {префикс {regex[index]} суфикс} вътре в текстов блок. Ако не е зададен [индекс], се използва първото съвпадение. Индексът може да бъде число, [*] (съединяване чрез интервал) или [*#10] (съединяване чрез нов ред). Ако регулярният израз не намери съвпадение, целият блок {…} се премахва. Използването на ~ вътре в регулярен израз връща целия текст.\n"
-"Инверсия: Започнете сегмент с ! (напр. !/path{Error}), за да покаже текста му само ако липсват данните за указателя или JSON е невалиден.\n"
-"Коментиране: /* текст */ коментарите се премахват от целия израз преди обработка.\n"
-"Примери:\n"
-"responseData/translatedText; съвпадения/*#10/превод; /текстове/текст; {буквен текст#10}; /резултат/текст; /текст{ ({(\\w+)})}; !/translations{Грешка: Няма данни!#10}; /преводи/0/текст"
+msgstr "Json показалец: Използва / за нива, ключове за обекти и числа за индекси. Използва * за всички елементи, *#10 за свързване на елементи чрез нов ред. Използвайте ~ в края на пътя, за да върнете необработения JSON клон. Разделете няколко сегмента с точка и запетая ;.\nЛитерал: Текстов блок в {…}. Специален етикет #10 за нови редове. Използвайте {{regex}} вътре, за да извлечете данни директно в текста.\nЛогика: Ако указател в сегмент е празен, целият сегмент се пропуска. Ако даден сегмент няма указател, се обработват само буквални текстови блокове с вградени регулярни изрази.\nRegex: {префикс {regex[index]} суфикс} вътре в текстов блок. Ако не е зададен [индекс], се използва първото съвпадение. Индексът може да бъде число, [*] (съединяване чрез интервал) или [*#10] (съединяване чрез нов ред). Ако регулярният израз не намери съвпадение, целият блок {…} се премахва. Използването на ~ вътре в регулярен израз връща целия текст.\nИнверсия: Започнете сегмент с ! (напр. !/path{Error}), за да покаже текста му само ако липсват данните за указателя или JSON е невалиден.\nКоментиране: /* текст */ коментарите се премахват от целия израз преди обработка.\nПримери:\nresponseData/translatedText; съвпадения/*#10/превод; /текстове/текст; {буквен текст#10}; /резултат/текст; /текст{ ({(\\w+)})}; !/translations{Грешка: Няма данни!#10}; /преводи/0/текст"
 
 #: tformconfigtrayslate.labellanguages.caption
 msgctxt "tformconfigtrayslate.labellanguages.caption"
@@ -634,9 +602,7 @@ msgstr "Тип стойност попълване на имена. None зап�
 msgid ""
 "Target languages e.g. en=en-US, en - internal, en-US - service code.\n"
 "If not specified, both source and target languages are taken from the languages section."
-msgstr ""
-"Целеви езици, например en=en-US, en - вътрешен, en-US - сервизен код.\n"
-"Ако не е посочено, и двата езика, изходният и целевият, се вземат от секцията за езици."
+msgstr "Целеви езици, например en=en-US, en - вътрешен, en-US - сервизен код.\nАко не е посочено, и двата езика, изходният и целевият, се вземат от секцията за езици."
 
 #: tformconfigtrayslate.labelmaxlength.caption
 msgid "Max Length, bytes"
@@ -789,11 +755,9 @@ msgid "Copy Translation"
 msgstr "Копирай превода"
 
 #: tformpopuptrayslate.afastautoheight.caption
-#, fuzzy
-#| msgid "Lock Auto Height"
 msgctxt "tformpopuptrayslate.afastautoheight.caption"
 msgid "Lock Height"
-msgstr "Заключи автоматичната височина"
+msgstr "Заключи височината"
 
 #: tformpopuptrayslate.anewtranslate.hint
 msgctxt "tformpopuptrayslate.anewtranslate.hint"
@@ -980,9 +944,7 @@ msgstr "Винаги предпочитай основен/вторичен ез
 msgid ""
 "Always prefer the Primary/Secondary language pair when the detected language matches the current target language.\n"
 "Restore the configured pair instead of performing a normal swap."
-msgstr ""
-"Винаги предпочитай двойка основен/вторичен език, когато откритият език съвпада с текущия целеви език. \n"
-"Възстанови конфигурирана двойка вместо нормална смяна."
+msgstr "Винаги предпочитай двойка основен/вторичен език, когато откритият език съвпада с текущия целеви език. \nВъзстанови конфигурирана двойка вместо нормална смяна."
 
 #: tformsettingstrayslate.checksmartswap.caption
 msgctxt "tformsettingstrayslate.checksmartswap.caption"
@@ -994,9 +956,7 @@ msgctxt "tformsettingstrayslate.checksmartswap.hint"
 msgid ""
 "If Detected language is outside the current pair, the Source language is replaced with the Detected language and the Target language is set to Primary.\n"
 "If Detected language equals Primary, the translation pair is set to Primary - Secondary."
-msgstr ""
-"Ако откритият език е извън текущата двойка, изходният се заменя с открития, а целевият е зададен на Основен.\n"
-"Ако Откритият език е Основен, двойката превод е зададена на Основен - Вторичен."
+msgstr "Ако откритият език е извън текущата двойка, изходният се заменя с открития, а целевият е зададен на Основен.\nАко Откритият език е Основен, двойката превод е зададена на Основен - Вторичен."
 
 #: tformsettingstrayslate.checkstayontop.caption
 msgid "Stay On Top"


### PR DESCRIPTION
Hi,
There was an untranslated line: 
<img width="1063" height="480" alt="sshot-1" src="https://github.com/user-attachments/assets/d2fa8d1a-8bd7-4ad5-ab37-145a2ace0ce4" />
I opened the "po file" in pobatch-v1.0 and noticed that there is no Text Search. It would be nice to add it.
